### PR TITLE
[FIX] ページ移動をした際の処理を変更

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,12 @@
 <template>
-  <Header v-if="isNotTop"/>
+  <Header v-if="isNotTop" :leaveTop="leaveTop" :moveTop="moveTop"/>
   <div id="nav">
-    <router-link to="/" v-on:click="leaveTop">Home</router-link> |
-    <router-link to="/about" v-on:click="leaveTop">About</router-link> |
-    <router-link to="/top" v-on:click="moveTop">Top</router-link>
+    <router-link to="/" @click="leaveTop">Home</router-link> |
+    <router-link to="/about" @click="leaveTop">About</router-link> |
+    <router-link to="/top" @click="moveTop">Top</router-link>
   </div>
-  <router-view />
-  <Footer />
+  <router-view :leaveTop="leaveTop" :moveTop="moveTop" />
+  <Footer :leaveTop="leaveTop" :moveTop="moveTop"/>
 </template>
 
 <script>
@@ -15,7 +15,7 @@ import Footer from "@/components/Footer.vue";
 export default {
   data() {
     return {
-      isNotTop: false
+      isNotTop: true
     }
   },
   methods: {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -2,7 +2,7 @@
   <div id="footer" class="container">
     <div class="row">
       <div id="access_top" class="col col-sm-3">
-        <router-link to="/top">
+        <router-link to="/top" @click="moveTop()">
           <!--
             <img alt="nmu_brass ico" src="../assets/_nmu_brass_ico.png" />
             -->
@@ -11,19 +11,29 @@
         </router-link>
       </div>
       <div id="menu" class="col col-md-auto">
-        <router-link to="/greeting">ご挨拶</router-link>
-        <router-link to="/news">お知らせ</router-link>
-        <router-link to="/about">活動紹介</router-link>
-        <router-link to="/advertise">部員募集</router-link>
+        <router-link to="/greeting" @click="leaveTop()">ご挨拶</router-link>
+        <router-link to="/news" @click="leaveTop()">お知らせ</router-link>
+        <router-link to="/about" @click="leaveTop()">活動紹介</router-link>
+        <router-link to="/advertise" @click="leaveTop()">部員募集</router-link>
         <br />
-        <router-link to="/request">演奏会のご依頼</router-link>
-        <router-link to="/archive">過去の演奏会</router-link>
-        <a href="" target="_blank" rel="noopener">部員ポータル</a>
-        <router-link to="/link">リンク</router-link>
+        <router-link to="/request" @click="leaveTop()">演奏会のご依頼</router-link>
+        <router-link to="/archive" @click="leaveTop()">過去の演奏会</router-link>
+        <a href="" target="_blank" rel="noopener" @click="leaveTop()">部員ポータル</a>
+        <router-link to="/link" @click="leaveTop()">リンク</router-link>
       </div>
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  name: "Footer",
+  props: {
+    leaveTop: Function,
+    moveTop: Function
+  }
+}
+</script>
 
 <style>
 #footer {
@@ -31,6 +41,9 @@
 }
 #footer a {
   color:#FFFFFF;
+}
+#footer {
+  width: 100%
 }
 #access_top {
   font-size: 14px;

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -2,7 +2,7 @@
   <div id="header" class="container">
     <div class="row">
       <div id="access_top" class="col col-sm-3">
-        <router-link to="/top">
+        <router-link to="/top" @click="moveTop()">
           <!--
             <img alt="nmu_brass ico" src="../assets/_nmu_brass_ico.png" />
             -->
@@ -11,18 +11,30 @@
         </router-link>
       </div>
       <div id="menu" class="col col-md-auto">
-        <router-link to="/greeting">ご挨拶</router-link>
-        <router-link to="/news">お知らせ</router-link>
-        <router-link to="/about">活動紹介</router-link>
-        <router-link to="/advertise">部員募集</router-link>
-        <router-link to="/request">演奏会のご依頼</router-link>
-        <router-link to="/archive">過去の演奏会</router-link>
-        <a href="" target="_blank" rel="noopener">部員ポータル</a>
-        <router-link to="/link">リンク</router-link>
+        <router-link to="/greeting" @click="leaveTop()">ご挨拶</router-link>
+        <router-link to="/news" @click="leaveTop()">お知らせ</router-link>
+        <router-link to="/about" @click="leaveTop()">活動紹介</router-link>
+        <router-link to="/advertise" @click="leaveTop()">部員募集</router-link>
+        <router-link to="/request" @click="leaveTop()">演奏会のご依頼</router-link>
+        <router-link to="/archive" @click="leaveTop()">過去の演奏会</router-link>
+        <a href="" target="_blank" rel="noopener" @click="leaveTop()">部員ポータル</a>
+        <router-link to="/link" @click="leaveTop()">リンク</router-link>
       </div>
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  name: "Header",
+  props: {
+    leaveTop: Function,
+    moveTop: Function
+  }
+}
+</script>
+
+
 <style>
 #access_top {
   font-size: 14px;

--- a/src/views/Top.vue
+++ b/src/views/Top.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="top">
-    <Header />
+    <Header :leaveTop="leaveTop" :moveTop="moveTop"/>
     <div class="name">
       <h1>Osaka Metropolitan University <br /> Brass Band</h1>
       <h5>大阪公立大学吹奏楽部</h5>
@@ -25,6 +25,10 @@ export default {
 //    Topics,
 //    SocialLiks,
   },
+  props: {
+    leaveTop: Function,
+    moveTop: Function
+  }
 };
 
 </script>


### PR DESCRIPTION
## 派生元のissue
#6 

## 概要
タイトルの通り

## 実装内容
トップページではヘッダーを内部に埋め込みたいので，ページ移動時にトップページ以外ではヘッダーを表示，トップページではヘッダーを表示しないように処理を変更

## 機能追加
関数を引き渡してヘッダーの表示・非表示を変更できるようにした